### PR TITLE
add missing label for consumerConnectionsCrashedTotal metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The exporter provides the following metrics.
 |kafka_consumer_connection_count|The current number of active connections established with a broker||0.8.0|
 |kafka_consumer_connection_creation_total|The total number of connections established with a broker||0.8.0|
 |kafka_consumer_connection_close_total|The total number of connections closed with a broker||0.8.0|
-|kafka_consumer_connection_crashed_total|The total number of crashed connections with a broker|<ul><li>_error_: The error which caused the connection crash.</li><li>_restart_: Determines of the connection was automatically restarted.</li><ul>|0.8.0|
+|kafka_consumer_connection_crashed_total|The total number of crashed connections with a broker|<ul><li>_group_id_: The id of the consumer group.</li><li>_error_: The error which caused the connection crash.</li><li>_restart_: Determines of the connection was automatically restarted.</li><ul>|0.8.0|
 |kafka_consumer_heartbeat_total|The total number of heartbeats with a broker|<ul><li>_group_id_: The id of the consumer group.</li><li>_member_id_: The member of the consumer group.</li><ul>|0.8.0|
 |kafka_consumer_request_queue_size|Size of the request queue.|<ul><li>_broker_: The broker</li><ul>|0.8.0|
 |kafka_consumer_request_total|The total number of requests sent.|<ul><li>_broker_: The broker</li><ul>|0.8.0|

--- a/src/kafkaJSConsumerPrometheusExporter.ts
+++ b/src/kafkaJSConsumerPrometheusExporter.ts
@@ -57,7 +57,7 @@ export class KafkaJSConsumerPrometheusExporter {
     this.consumerConnectionsCrashedTotal = new Counter({
       name: 'kafka_consumer_connection_crashed_total',
       help: 'The total number of crashed connections with a broker',
-      labelNames: mergeLabelNamesWithStandardLabels(['error', 'restart'], this.options.defaultLabels),
+      labelNames: mergeLabelNamesWithStandardLabels(['group_id', 'error', 'restart'], this.options.defaultLabels),
       registers: [this.register]
     })
 

--- a/test/metricsKafkaJSConsumer.spec.ts
+++ b/test/metricsKafkaJSConsumer.spec.ts
@@ -65,7 +65,7 @@ describe('test if all metrics are created with the correct parameters', () => {
     expect(Counter).toHaveBeenCalledWith({
       name: 'kafka_consumer_connection_crashed_total',
       help: 'The total number of crashed connections with a broker',
-      labelNames: ['error', 'restart'],
+      labelNames: ['group_id', 'error', 'restart'],
       registers: [register]
     })
 
@@ -160,7 +160,7 @@ describe('test if all metrics are created with the correct parameters', () => {
     expect(Counter).toHaveBeenCalledWith({
       name: 'kafka_consumer_connection_crashed_total',
       help: 'The total number of crashed connections with a broker',
-      labelNames: ['error', 'restart', 'foo', 'alice'],
+      labelNames: ['group_id', 'error', 'restart', 'foo', 'alice'],
       registers: [register]
     })
 


### PR DESCRIPTION
Hey,

First of all, thanks for the package.

We have a prom-client validation error in our logs: `Added label "group_id" is not included in initial labelset: [ 'error', 'restart', 'clientId' ]`, with a stack-trace pointing to the connection-crashed metric.

